### PR TITLE
Add FastAPI time endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # test
 
 This repository is used to test creating a pull request.
+
+## FastAPI application
+
+The project now includes a small FastAPI application with a single `/time`
+endpoint that returns the current UTC time. Run the application with:
+
+```bash
+python main.py
+```
+
+Access `http://localhost:8000/time` to see the current time in ISO format.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,24 @@
-def main():
-    return "Hello world"
+from datetime import datetime, timezone
+from fastapi import FastAPI
+
+
+async def get_current_time() -> dict[str, str]:
+    """Return the current UTC time in ISO format."""
+    return {"time": datetime.now(tz=timezone.utc).isoformat()}
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+
+    app.add_api_route("/time", get_current_time, methods=["GET"])
+
+    return app
+
+
+app = create_app()
+
 
 if __name__ == "__main__":
-    print(main())
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "fastapi[standard]",
+]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,21 @@
-import main
+import asyncio
+from datetime import datetime, timezone
+import unittest
 
-def test_main_returns_hello_world():
-    assert main.main() == "Hello world"
+from main import get_current_time
+
+
+class GetCurrentTimeTest(unittest.TestCase):
+    def test_returns_iso_datetime(self):
+        data = asyncio.run(get_current_time())
+        self.assertIn("time", data)
+        # Ensure the time can be parsed as an ISO formatted datetime
+        datetime.fromisoformat(data["time"])
+
+    def test_time_is_current_to_the_second(self):
+        before = datetime.now(tz=timezone.utc).replace(microsecond=0)
+        data = asyncio.run(get_current_time())
+        returned_time = datetime.fromisoformat(data["time"]).replace(microsecond=0)
+        after = datetime.now(tz=timezone.utc).replace(microsecond=0)
+
+        self.assertTrue(before <= returned_time <= after)


### PR DESCRIPTION
## Summary
- add `fastapi[standard]` dependency
- convert `main.py` to a FastAPI app
- expose `/time` endpoint returning current UTC time
- update tests for new endpoint
- document usage in README
- add additional test to check time accuracy to the second

## Testing
- `python -m unittest discover -v`
